### PR TITLE
Exclude headers from hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,15 @@ $ curl -X POST -d "yay" http://localhost:4567; echo
 var hash = require('incoming-message-hash');
 ```
 
-### hash([algorithm='md5'[, encoding='hex']])
+### hash([options])
 
-Returns a new [crypto.Hash][] stream using the specified algorithm and encoding (defaults to "md5" and "hex"). You can pipe your [http.IncomingMessage][] in and get a hash back.
+Returns a new [crypto.Hash][] stream using the specified algorithm and encoding (defaults to "md5" and "hex"). You can pipe your [http.IncomingMessage][] in and get a hash back. You can also specify which headers should be excluded when creating the hash.
+
+#### options
+
+- `algorithm` the algorithm to use when hashing
+- `encoding` the encoding to use when hashing
+- `excludeHeaders` an array of headers that should be excluded from the hash
 
 [http.IncomingMessage]: https://nodejs.org/api/http.html#http_class_http_incomingmessage
 [crypto.Hash]: https://nodejs.org/api/crypto.html#crypto_class_hash

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Returns a new [crypto.Hash][] stream using the specified algorithm and encoding 
 [http.IncomingMessage]: https://nodejs.org/api/http.html#http_class_http_incomingmessage
 [crypto.Hash]: https://nodejs.org/api/crypto.html#crypto_class_hash
 
-### hash.sync(req, body, [algorithm='md5'[, encoding='hex']])
+### hash.sync(req, body, [options])
 
 Synchronous version of `hash()` that accepts the http.IncomingMessage and its body and returns the hash. You must buffer up the request body yourself if you wish to use this method.
 

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -24,6 +24,9 @@ exports['produces a different hash for a different method'] =
 exports['produces a different hash for different headers'] =
   '46e486ddb60f2236f77c8bbe29d6c760';
 
+exports['produces the same hash for different headers if excludeHeaders option is specified'] =
+  '09a3df93c944461cee09969f2a4bb848';
+
 exports['produces a different hash for a different post body'] =
   'e84cf2827fbc172a5957e3b29a1f47d5';
 

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -27,6 +27,9 @@ exports['produces a different hash for different headers'] =
 exports['produces the same hash for different headers if excludeHeaders option is specified'] =
   '09a3df93c944461cee09969f2a4bb848';
 
+exports['produces the same hash for different headers if includeHeaders option is specified'] =
+  '09a3df93c944461cee09969f2a4bb848';
+
 exports['produces a different hash for a different post body'] =
   'e84cf2827fbc172a5957e3b29a1f47d5';
 

--- a/test/harness.js
+++ b/test/harness.js
@@ -55,6 +55,18 @@ module.exports = function (app) {
     .expect(fixture[this.test.title], done);
   });
 
+  it('produces the same hash for different headers if excludeHeaders option is specified', function (done) {
+    request(app({
+      excludeHeaders: [
+        'x-foo'
+      ]
+    }))
+    .get('/')
+    .set('host', 'localhost:4567')
+    .set('x-foo', 'bar')
+    .expect(fixture[this.test.title], done);
+  });
+
   it('produces a different hash for a different post body', function (done) {
     request(app())
     .post('/')
@@ -64,14 +76,14 @@ module.exports = function (app) {
   });
 
   it('can use a different hash algorithm', function (done) {
-    request(app('sha1'))
+    request(app({ algorithm: 'sha1' }))
     .get('/')
     .set('host', 'localhost:4567')
     .expect(fixture[this.test.title], done);
   });
 
   it('can use a different encoding', function (done) {
-    request(app('md5', 'base64'))
+    request(app({ encoding: 'base64' }))
     .get('/')
     .set('host', 'localhost:4567')
     .expect(fixture[this.test.title], done);

--- a/test/harness.js
+++ b/test/harness.js
@@ -67,6 +67,21 @@ module.exports = function (app) {
     .expect(fixture[this.test.title], done);
   });
 
+  it('produces the same hash for different headers if includeHeaders option is specified', function (done) {
+    request(app({
+      includeHeaders: [
+        'host',
+        'accept-encoding',
+        'user-agent',
+        'connection'
+      ]
+    }))
+    .get('/')
+    .set('host', 'localhost:4567')
+    .set('x-foo', 'bar')
+    .expect(fixture[this.test.title], done);
+  });
+
   it('produces a different hash for a different post body', function (done) {
     request(app())
     .post('/')


### PR DESCRIPTION
I'd like to be able to exclude certain http headers from the hash. This is in preparation for being able to do so in [yakbak](https://github.com/flickr/yakbak), so that when running integration tests, they don't fail due to a different user-agent header (e.g. phantomjs instead of chrome).